### PR TITLE
Add repository flag support

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -8,7 +8,8 @@
    - `gh extension create gh-discussion` を利用して拡張ディレクトリを生成。
    - 言語は Go を使用（`gh` 本体との親和性が高い）。
 2. **検索コマンド (search)**
-   - オプション: `--from`, `--to`, `--user`, `--keyword` (複数指定可)。
+   - オプション: `--from`, `--to`, `--user`, `--keyword`, `--repo` (複数指定可)。
+   - `--repo` で検索対象のリポジトリを `owner/repo` 形式で指定可能。
    - 入力された条件をもとに検索クエリを組み立てて GitHub GraphQL API の `search` を利用。
    - 取得項目: タイトル、URL、作成者、作成日時、コメント数などを一覧で表示。
 3. **内容取得コマンド (view)**

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ gh extension install harakeishi/gh-discussion
 ## Usage
 - Search discussions:
 ```
-gh discussion search --from 2023-01-01 --to 2023-01-31 --keyword bug
+gh discussion search --repo owner/repo --from 2023-01-01 --to 2023-01-31 --keyword bug
 ```
 - View discussion:
 ```

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,24 +1,27 @@
 package main
 
 import (
-    "os"
-    "github.com/spf13/cobra"
+	"github.com/spf13/cobra"
+	"os"
 )
 
-func newRootCmd() *cobra.Command {
-    cmd := &cobra.Command{
-        Use:   "gh-discussion",
-        Short: "Interact with GitHub Discussions",
-    }
+var repo string
 
-    cmd.AddCommand(newSearchCmd())
-    cmd.AddCommand(newViewCmd())
-    return cmd
+func newRootCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "gh-discussion",
+		Short: "Interact with GitHub Discussions",
+	}
+
+	cmd.PersistentFlags().StringVar(&repo, "repo", "", "target repository (owner/repo)")
+
+	cmd.AddCommand(newSearchCmd())
+	cmd.AddCommand(newViewCmd())
+	return cmd
 }
 
 func main() {
-    if err := newRootCmd().Execute(); err != nil {
-        os.Exit(1)
-    }
+	if err := newRootCmd().Execute(); err != nil {
+		os.Exit(1)
+	}
 }
-

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -43,7 +43,7 @@ func newSearchCmd() *cobra.Command {
 				to = &t
 			}
 
-			query := buildSearchQuery(from, to, user, keywords)
+			query := buildSearchQuery(from, to, user, repo, keywords)
 			results, err := searchDiscussions(query)
 			if err != nil {
 				return err
@@ -62,7 +62,7 @@ func newSearchCmd() *cobra.Command {
 	return cmd
 }
 
-func buildSearchQuery(from, to *time.Time, user string, keywords []string) string {
+func buildSearchQuery(from, to *time.Time, user, repo string, keywords []string) string {
 	var parts []string
 	if from != nil {
 		parts = append(parts, fmt.Sprintf("created:%s..", from.Format("2006-01-02")))
@@ -78,6 +78,9 @@ func buildSearchQuery(from, to *time.Time, user string, keywords []string) strin
 	}
 	if user != "" {
 		parts = append(parts, "author:"+user)
+	}
+	if repo != "" {
+		parts = append(parts, "repo:"+repo)
 	}
 	for _, kw := range keywords {
 		parts = append(parts, kw)

--- a/cmd/search_test.go
+++ b/cmd/search_test.go
@@ -1,25 +1,25 @@
 package main
 
 import (
-    "testing"
-    "time"
+	"testing"
+	"time"
 )
 
 func TestBuildSearchQuery(t *testing.T) {
-    from := parseDate(t, "2023-01-01")
-    to := parseDate(t, "2023-01-31")
-    q := buildSearchQuery(&from, &to, "alice", []string{"bug"})
-    expected := "created:2023-01-01..2023-01-31 author:alice bug"
-    if q != expected {
-        t.Fatalf("expected %q, got %q", expected, q)
-    }
+	from := parseDate(t, "2023-01-01")
+	to := parseDate(t, "2023-01-31")
+	q := buildSearchQuery(&from, &to, "alice", "cli/cli", []string{"bug"})
+	expected := "created:2023-01-01..2023-01-31 author:alice repo:cli/cli bug"
+	if q != expected {
+		t.Fatalf("expected %q, got %q", expected, q)
+	}
 }
 
 func parseDate(t *testing.T, v string) time.Time {
-    t.Helper()
-    dt, err := time.Parse("2006-01-02", v)
-    if err != nil {
-        t.Fatal(err)
-    }
-    return dt
+	t.Helper()
+	dt, err := time.Parse("2006-01-02", v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return dt
 }


### PR DESCRIPTION
## Summary
- document ability to specify repository when searching discussions
- add persistent `--repo` flag
- pass `repo` to search query builder
- support repo option in `buildSearchQuery` and tests

## Testing
- `go test ./...` *(fails: no module for github.com/spf13/cobra)*

------
https://chatgpt.com/codex/tasks/task_e_68479e7c31e883299c51c0c22c58a367