### PR TITLE
Add cobra dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,7 @@
 module github.com/harakeishi/gh-discussion
 
 go 1.23.8
+
+require (
+    github.com/spf13/cobra v1.7.0
+)


### PR DESCRIPTION
## Summary
- add cobra dependency to go.mod

## Testing
- `go mod tidy` *(fails: Get "https://proxy.golang.org/github.com/spf13/cobra/...": Forbidden)*
- `go test ./...` *(fails: missing go.sum entry)*


------
https://chatgpt.com/codex/tasks/task_e_6847b32c47f88329a54361cd8e95d25f